### PR TITLE
Fix integration connection between backend and frontend

### DIFF
--- a/app/dashboard/integrations/airtable/page.tsx
+++ b/app/dashboard/integrations/airtable/page.tsx
@@ -39,6 +39,7 @@ export default function AirtableIntegrationPage() {
       }
     } catch (error) {
       console.error("Error fetching data:", error)
+      setError(error.message)
     } finally {
       setIsLoading(false)
     }

--- a/app/dashboard/integrations/hubspot/page.tsx
+++ b/app/dashboard/integrations/hubspot/page.tsx
@@ -31,14 +31,15 @@ export default function HubspotIntegrationPage() {
       }
 
       if (status.status === "active") {
-        setData(status)
+        setData(status.workspace)
       } else {
         await syncIntegrationData("hubspot", userId)
         const updatedStatus = await getIntegrationStatus("hubspot", userId)
-        setData(updatedStatus)
+        setData(updatedStatus.workspace)
       }
     } catch (error) {
       console.error("Error fetching data:", error)
+      setError(error.message)
     } finally {
       setIsLoading(false)
     }

--- a/app/dashboard/integrations/notion/page.tsx
+++ b/app/dashboard/integrations/notion/page.tsx
@@ -39,6 +39,7 @@ export default function NotionIntegrationPage() {
       }
     } catch (error) {
       console.error("Error fetching data:", error)
+      setError(error.message)
     } finally {
       setIsLoading(false)
     }

--- a/app/dashboard/integrations/slack/page.tsx
+++ b/app/dashboard/integrations/slack/page.tsx
@@ -31,14 +31,15 @@ export default function SlackIntegrationPage() {
       }
 
       if (status.status === "active") {
-        setData(status)
+        setData(status.workspace)
       } else {
         await syncIntegrationData("slack", userId)
         const updatedStatus = await getIntegrationStatus("slack", userId)
-        setData(updatedStatus)
+        setData(updatedStatus.workspace)
       }
     } catch (error) {
       console.error("Error fetching data:", error)
+      setError(error.message)
     } finally {
       setIsLoading(false)
     }
@@ -136,16 +137,16 @@ export default function SlackIntegrationPage() {
                     <thead>
                       <tr className="border-b bg-muted/50">
                         <th className="p-2 text-left font-medium">Name</th>
-                        <th className="p-2 text-left font-medium">Members</th>
-                        <th className="p-2 text-left font-medium">Messages</th>
+                        <th className="p-2 text-left font-medium">Visibility</th>
+                        <th className="p-2 text-left font-medium">Creation Time</th>
                       </tr>
                     </thead>
                     <tbody>
                       {data.channels?.map((channel: any) => (
                         <tr key={channel.id} className="border-b">
                           <td className="p-2">#{channel.name}</td>
-                          <td className="p-2">{channel.members}</td>
-                          <td className="p-2">{channel.messages}</td>
+                          <td className="p-2">{channel.visibility ? "Public" : "Private"}</td>
+                          <td className="p-2">{new Date(parseInt(channel.creation_time) * 1000).toLocaleDateString()}</td>
                         </tr>
                       ))}
                     </tbody>
@@ -162,27 +163,8 @@ export default function SlackIntegrationPage() {
                 <CardDescription>Recent messages from your Slack workspace</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="rounded-md border">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="border-b bg-muted/50">
-                        <th className="p-2 text-left font-medium">Channel</th>
-                        <th className="p-2 text-left font-medium">User</th>
-                        <th className="p-2 text-left font-medium">Message</th>
-                        <th className="p-2 text-left font-medium">Time</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {data.messages.map((message: any) => (
-                        <tr key={message.id} className="border-b">
-                          <td className="p-2">#{message.channel}</td>
-                          <td className="p-2">{message.user}</td>
-                          <td className="p-2">{message.text}</td>
-                          <td className="p-2">{new Date(message.timestamp).toLocaleString()}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                <div className="text-center py-4">
+                  <p className="text-muted-foreground">Message data will be displayed here when available</p>
                 </div>
               </CardContent>
             </Card>
@@ -195,30 +177,8 @@ export default function SlackIntegrationPage() {
                 <CardDescription>Users in your Slack workspace</CardDescription>
               </CardHeader>
               <CardContent>
-                <div className="rounded-md border">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="border-b bg-muted/50">
-                        <th className="p-2 text-left font-medium">Name</th>
-                        <th className="p-2 text-left font-medium">Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {data.users.map((user: any) => (
-                        <tr key={user.id} className="border-b">
-                          <td className="p-2">{user.name}</td>
-                          <td className="p-2">
-                            <span
-                              className={`inline-block w-2 h-2 rounded-full mr-2 ${
-                                user.status === "active" ? "bg-green-500" : "bg-yellow-500"
-                              }`}
-                            ></span>
-                            {user.status}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                <div className="text-center py-4">
+                  <p className="text-muted-foreground">User data will be displayed here when available</p>
                 </div>
               </CardContent>
             </Card>

--- a/backend/routes/integrations.py
+++ b/backend/routes/integrations.py
@@ -171,11 +171,13 @@ async def get_integration_status(
     """Get integration status and workspace info"""
     try:
         provider_funcs = get_provider_functions(provider)
+        credentials = await provider_funcs["get_credentials"](user_id, current_user["id"])
+        items = await provider_funcs["get_items"](credentials)
         return {
             "isConnected": True,
             "status": "active",
             "lastSync": "2025-03-12T12:00:00Z",
-            "workspace": provider_funcs["mock_data"]
+            "workspace": items
         }
     except Exception as e:
         return {
@@ -192,7 +194,15 @@ async def sync_integration(
 ):
     """Sync integration data"""
     try:
-        return await get_integration_status(provider, user_id)
+        provider_funcs = get_provider_functions(provider)
+        credentials = await provider_funcs["get_credentials"](user_id, current_user["id"])
+        items = await provider_funcs["get_items"](credentials)
+        return {
+            "isConnected": True,
+            "status": "active",
+            "lastSync": "2025-03-12T12:00:00Z",
+            "workspace": items
+        }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
Update the frontend and backend to connect integrations for Notion, Airtable, HubSpot, and Slack.

* **Frontend Changes:**
  - Update `fetchData` functions in `app/dashboard/integrations/notion/page.tsx`, `app/dashboard/integrations/airtable/page.tsx`, `app/dashboard/integrations/hubspot/page.tsx`, and `app/dashboard/integrations/slack/page.tsx` to handle errors and set the `error` state with the error message.
  - Modify `app/dashboard/integrations/hubspot/page.tsx` and `app/dashboard/integrations/slack/page.tsx` to set the `data` state with the workspace data.
  - Update the Slack integration page to display channel visibility and creation time, and remove the display of recent messages and users.

* **Backend Changes:**
  - Update `get_integration_status` and `sync_integration` functions in `backend/routes/integrations.py` to call the respective provider's `get_items` function and return the fetched data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/vectorshift/pull/5?shareId=7e940306-6deb-4f2c-9690-1a7b4d957ccb).