### PR TITLE
Add technical paper, README, and MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 VectorShift
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# VectorShift
+
+VectorShift is a comprehensive platform that integrates various third-party services to provide a seamless experience for managing and visualizing data. The platform consists of a backend implemented using FastAPI and a frontend implemented using Next.js.
+
+## Overview
+
+The backend is responsible for handling authentication, managing integrations with third-party services, and providing APIs for the frontend. The frontend is responsible for providing a user-friendly interface for managing and visualizing data from the integrated services.
+
+## Backend
+
+The backend is implemented using FastAPI and consists of the following components:
+
+- **Authentication**: Managed using JWT tokens, with routes defined in `backend/auth_routes.py`.
+- **Dashboard**: Provides user-specific dashboard data, with routes defined in `backend/routes/dashboard.py`.
+- **Integrations**: Handles integration with third-party services like Google, Airtable, Notion, Slack, and HubSpot, with routes defined in `backend/routes/integrations.py`.
+- **Profiles**: Manages user profiles, with routes defined in `backend/routes/profiles.py`.
+- **Middleware**: Authentication middleware defined in `backend/middleware.py`.
+
+## Frontend
+
+The frontend is implemented using Next.js and consists of the following components:
+
+- **Dashboard**: Provides a user-friendly interface for managing and visualizing data from the integrated services, with components located in the `app/components/dashboard` directory.
+- **Integrations**: Handles the integration process with third-party services, with components located in the `app/components/integrations` directory.
+- **Authentication**: Manages user authentication, with components located in the `app/components/auth` directory.
+
+## Setup Instructions
+
+### Backend
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/kasinadhsarma/vectorshift.git
+   cd vectorshift
+   ```
+
+2. Navigate to the backend directory:
+   ```bash
+   cd backend
+   ```
+
+3. Create a virtual environment and activate it:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+
+4. Install the required dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+5. Set up environment variables:
+   ```bash
+   cp .env.example .env
+   ```
+
+6. Start the backend server:
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+### Frontend
+
+1. Navigate to the frontend directory:
+   ```bash
+   cd ../frontend
+   ```
+
+2. Install the required dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Set up environment variables:
+   ```bash
+   cp .env.example .env
+   ```
+
+4. Start the frontend development server:
+   ```bash
+   npm run dev
+   ```
+
+## Usage Instructions
+
+1. Open your browser and navigate to `http://localhost:3000` to access the frontend.
+2. Sign up or log in to your account.
+3. Connect your desired third-party services through the integrations page.
+4. Manage and visualize your data through the dashboard.
+
+For more detailed information, refer to the technical paper located in the `docs` directory.

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -1,0 +1,64 @@
+# Technical Paper: Backend and Frontend Architecture
+
+## Backend Implementation using FastAPI
+
+The backend of the project is implemented using FastAPI. The following are the key components and routes defined in the backend:
+
+### Authentication Routes
+- **File:** `backend/auth_routes.py`
+- **Description:** This file contains the routes for user authentication, including signup, login, password reset, and token verification.
+
+### Dashboard Routes
+- **File:** `backend/routes/dashboard.py`
+- **Description:** This file contains the routes for fetching and refreshing user-specific dashboard data, including integration statistics and sync data.
+
+### Integration Routes
+- **File:** `backend/routes/integrations.py`
+- **Description:** This file contains the routes for handling OAuth authorization, fetching credentials, and syncing data for various third-party integrations like Notion, Airtable, Slack, and HubSpot.
+
+### Profile Routes
+- **File:** `backend/routes/profiles.py`
+- **Description:** This file contains the routes for fetching and updating user profile information.
+
+## Frontend Implementation using Next.js
+
+The frontend of the project is implemented using Next.js. The following are the key components and their locations:
+
+### Dashboard Components
+- **File:** `app/components/dashboard/dashboard-content.tsx`
+- **Description:** This file contains the main dashboard component that displays integration statistics, active integrations, and data visualization tabs.
+
+- **File:** `app/components/dashboard/data-visualization.tsx`
+- **Description:** This file contains the component for visualizing integration data in different formats like charts, tables, and metrics.
+
+## Integration with Third-Party Services
+
+The project integrates with various third-party services like Google, Airtable, Notion, Slack, and HubSpot. The integration logic is handled in the following files:
+
+### Google Integration
+- **File:** `backend/integrations/google_auth.py`
+- **Description:** This file contains the logic for Google OAuth authentication, including generating the authorization URL, handling the callback, and fetching user information.
+
+### Airtable Integration
+- **File:** `backend/integrations/airtable.py`
+- **Description:** This file contains the logic for Airtable OAuth authentication, including generating the authorization URL, handling the callback, and fetching bases and tables.
+
+### Notion Integration
+- **File:** `backend/integrations/notion.py`
+- **Description:** This file contains the logic for Notion OAuth authentication, including generating the authorization URL, handling the callback, and fetching databases and pages.
+
+### Slack Integration
+- **File:** `backend/integrations/slack.py`
+- **Description:** This file contains the logic for Slack OAuth authentication, including generating the authorization URL, handling the callback, and fetching channels.
+
+### HubSpot Integration
+- **File:** `backend/integrations/hubspot.py`
+- **Description:** This file contains the logic for HubSpot OAuth authentication, including generating the authorization URL, handling the callback, and fetching contacts.
+
+## Authentication Management using JWT Tokens
+
+Authentication in the project is managed using JWT tokens. The middleware for handling JWT authentication is defined in the following file:
+
+### JWT Middleware
+- **File:** `backend/middleware.py`
+- **Description:** This file contains the middleware for verifying JWT tokens, extracting user information, and handling CORS configuration.


### PR DESCRIPTION
Add technical paper, README, and MIT license to the project.

* **Technical Paper**: 
  - Add `docs/technical-paper.md` detailing backend and frontend architecture.
  - Document backend implementation using FastAPI, including routes for authentication, dashboard, integrations, and profiles.
  - Document frontend implementation using Next.js, including dashboard components.
  - Document integration with third-party services like Google, Airtable, Notion, Slack, and HubSpot.
  - Document authentication management using JWT tokens.

* **README**:
  - Add `README.md` providing an overview of the project.
  - Include setup instructions for the backend and frontend.
  - Include usage instructions for the project.

* **License**:
  - Add `LICENSE` file with MIT License text.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/vectorshift/pull/6?shareId=c9692e97-b8cf-4b7c-8d0d-ace0d60b5c1e).