### PR TITLE
Fix Google login functionality

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routers.integrations import router as integrations_router
+from backend.integrations.google_auth import google_auth_url
 
 app = FastAPI()
 
@@ -16,6 +17,11 @@ app.add_middleware(
 
 # Include routers
 app.include_router(integrations_router)
+
+@app.get("/auth/google/url")
+async def get_google_auth_url():
+    """Endpoint to get Google auth URL."""
+    return {"url": await google_auth_url()}
 
 @app.get("/health")
 async def health_check():


### PR DESCRIPTION
Add a new route to handle the initial Google auth URL request.

* Import the `google_auth_url` function from `backend/integrations/google_auth.py`.
* Define a new endpoint `/auth/google/url` in `backend/main.py` to return the Google auth URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/vectorshift/pull/11?shareId=5c7eae3f-658a-46cc-8bdc-16e999fa32e1).